### PR TITLE
More verbose instructions for creating sqlite database

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -10,10 +10,25 @@ Instructions to run the server locally.
 ## Installation
 
  1. Execute db/\*.sql scripts to create and fill db/vchess.sqlite
- 2. Rename and edit config/parameters.js.dist into parameters.js
- 3. npm install
 
-Then run with the command
+```
+cd server/db
+sqlite3 vchess.sqlite.db
+sqlite> .read create.sql
+sqlite> .read populate.sql
+sqlite> .exit
+```
+
+ 2. Rename and edit `config/parameters.js.dist` into `config/parameters.js`
+
+ 3. Install npm modules
+ 
+ ```
+ npm install
+ ```
+
+ ## Running
+
 ```
 npm start
 ```


### PR DESCRIPTION
For a user not familiar with sqlite3, it is not clear how to create and populate the server's sqlite database. Before running scripts, you have to create the database with giving its name ( this was not mentioned in the ReadMe ) and then execute the scripts. A user can look up how to run an sqlite3 script, but a ReadMe had better be self contained and give the explicit console commands.

**This pull request updates the server installation ReadMe to be more verbose and explicit, so that an sqlite3 noob can understand and execute it.**