### PR TITLE
Use path.sep instead of hardcoded path separators in module path replacements

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -13,7 +13,7 @@ Instructions to run the server locally.
 
 ```
 cd server/db
-sqlite3 vchess.sqlite.db
+sqlite3 vchess.sqlite
 sqlite> .read create.sql
 sqlite> .read populate.sql
 sqlite> .exit

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -1,7 +1,8 @@
+const path = require('path')
 let router = require("express").Router();
 const access = require("../utils/access");
-const sendEmail = require(__dirname.replace("/routes", "/utils/mailer"));
-const params = require(__dirname.replace("/routes", "/config/parameters"));
+const sendEmail = require(__dirname.replace(`${path.sep}routes`, `${path.sep}utils${path.sep}mailer`));
+const params = require(__dirname.replace(`${path.sep}routes`, `${path.sep}config${path.sep}parameters`));
 
 // Send a message through contact form
 router.post("/messages", access.ajax, (req,res) => {

--- a/server/utils/database.js
+++ b/server/utils/database.js
@@ -1,9 +1,10 @@
+const path = require('path')
 const sqlite3 = require('sqlite3');
 const params = require("../config/parameters")
 
 if (params.env == "development") sqlite3.verbose();
 
-const DbPath = __dirname.replace("/utils", "/db/vchess.sqlite");
+const DbPath = __dirname.replace(`${path.sep}utils`, `${path.sep}db${path.sep}vchess.sqlite`);
 const db = new sqlite3.Database(DbPath);
 
 module.exports = db;


### PR DESCRIPTION
Hard coding "/" path separator in module path replacements won't work under Windows ( not even under cygwin ).

**This pull request replaces hard coded path separators in module path replacements with `path.sep`. Plus fixes a typo in server ReadMe.**

https://nodejs.org/api/path.html#path_path_sep